### PR TITLE
fix: correct LDPlayer9 adb port formula

### DIFF
--- a/COCBot/functions/Android/AndroidLDPlayer9.au3
+++ b/COCBot/functions/Android/AndroidLDPlayer9.au3
@@ -140,10 +140,10 @@ Func InitLDPlayer9($bCheckOnly = False)
 		Return False
 	EndIf
 	
-	Local $iAdbPort, $iAdbPortBase = 5555
+	Local $iAdbPort, $iAdbPortBase = 5554
 	Local $iInstance = StringReplace($g_sAndroidInstance, "leidian", "")
-	
-	$iAdbPort = $iAdbPortBase + $iInstance
+
+	$iAdbPort = $iAdbPortBase + 2 * $iInstance
 	$g_sAndroidAdbDevice = "emulator-" & $iAdbPort
 	
 	If $bInstalled And Not $bCheckOnly Then		


### PR DESCRIPTION
# Problem

The bot was using the old LDPlayer4-era formula (5555 + instance)

Because of this, the bot could calculate the wrong ADB device address for LDPlayer9 instances and fail to connect to the intended emulator.

# Fix 

LDPlayer9 It uses (5554 + 2*instance) for the port calculation, not the old formula. 