### PR TITLE
Fix/bb new building skip loop

### DIFF
--- a/COCBot/MBR Global Variables.au3
+++ b/COCBot/MBR Global Variables.au3
@@ -962,6 +962,7 @@ Global $g_aUpgradeResourceCostDuration[3] = ["", "", ""] ; Resource, Cost, Durat
 ; Builder Base
 Global $g_bAutoUpgradeBBEnabled = False, $g_bChkAutoUpgradeBBIgnoreHall = False, $g_bChkAutoUpgradeBBIgnoreWall = False, $g_bChkBBSpendGoldOnWall = False
 Global $g_bReserveElixirBB = False, $g_bReserveGoldBB = False, $g_bChkBOBControl = False
+Global $g_bChkBBIgnoreBOTOShack = True ; B.O.T.O's Shack (extra builder, Gem cost) — off by default, most users are focused on Home Village gems
 Global $g_bStayOnBuilderBase = False
 
 Global $g_iQuickMISX = 0, $g_iQuickMISY = 0, $g_sQuickMISName = "", $g_iQuickMISLevel = ""

--- a/COCBot/functions/Config/readConfig.au3
+++ b/COCBot/functions/Config/readConfig.au3
@@ -445,6 +445,7 @@ Func ReadConfig_600_6()
 	IniReadS($g_bChkAutoUpgradeBBIgnoreWall, $g_sProfileConfigPath, "other", "ChkBBSuggestedUpgradesIgnoreWall", False, "Bool")
 	IniReadS($g_bChkBBSpendGoldOnWall, $g_sProfileConfigPath, "other", "ChkBBSpendGoldOnWall", False, "Bool")
 	IniReadS($g_bChkBOBControl, $g_sProfileConfigPath, "other", "ChkBOBControl", False, "Bool")
+	IniReadS($g_bChkBBIgnoreBOTOShack, $g_sProfileConfigPath, "other", "ChkBBIgnoreBOTOShack", True, "Bool")
 
 	# NEW CLANGAMES GUI
 	IniReadS($g_bChkClanGamesEnabled, $g_sProfileConfigPath, "other", "ChkClanGamesEnabled", False, "Bool")

--- a/COCBot/functions/Config/saveConfig.au3
+++ b/COCBot/functions/Config/saveConfig.au3
@@ -413,6 +413,7 @@ Func SaveConfig_600_6()
 	_Ini_Add("other", "ChkBBSuggestedUpgradesIgnoreWall", $g_bChkAutoUpgradeBBIgnoreWall)
 	_Ini_Add("other", "ChkBBSpendGoldOnWall", $g_bChkBBSpendGoldOnWall)
 	_Ini_Add("other", "ChkBOBControl", $g_bChkBOBControl)
+	_Ini_Add("other", "ChkBBIgnoreBOTOShack", $g_bChkBBIgnoreBOTOShack)
 
 	# NEW CLANGAMES GUI
 	_Ini_Add("other", "ChkClanGamesEnabled", $g_bChkClanGamesEnabled ? 1 : 0)

--- a/COCBot/functions/Village/BuilderBase/SuggestedUpgrades.au3
+++ b/COCBot/functions/Village/BuilderBase/SuggestedUpgrades.au3
@@ -77,8 +77,13 @@ Func _SearchUpgradeBB($bTest = False)
 			Next
 			
 			For $i = 0 To UBound($Upgrades) - 1
-				If $Upgrades[$i][4] = "New" Then ;new building					
-					If CheckResourceForDoUpgradeBB($Upgrades[$i][3], $Upgrades[$i][5], $Upgrades[$i][0]) Then 
+				If $Upgrades[$i][4] = "New" Then ;new building
+					;B.O.T.O's Shack, Gem-cost only, off by default (name match tolerates OCR noise like "B O T O s Shack")
+					If $g_bChkBBIgnoreBOTOShack And StringInStr(StringRegExpReplace($Upgrades[$i][3], "[^A-Za-z]", ""), "BOTO", 2) Then
+						SetLog($Upgrades[$i][3] & " ignored (BOTO's Shack, Gem cost)", $COLOR_DEBUG2)
+						ContinueLoop
+					EndIf
+					If CheckResourceForDoUpgradeBB($Upgrades[$i][3], $Upgrades[$i][5], $Upgrades[$i][0]) Then
 						If PlaceNewBuildingFromShopBB($Upgrades[$i][3], $ZoomedIn, $Upgrades[$i][5]) Then
 							$ZoomedIn = True
 							$sameCost = 0
@@ -87,7 +92,7 @@ Func _SearchUpgradeBB($bTest = False)
 							If Not AutoUpgradeBBCheckBuilder($bTest) Then ExitLoop 2
 						Else
 							If IsFullScreenWindow() Then Click(820, 37) ;close shop window
-							ExitLoop
+							ContinueLoop ;don't let one failed New entry block the rest of the queue
 						EndIf
 					Else
 						SetLog("Not Enough " & $Upgrades[$i][0] & " for New Upgrade: " & $Upgrades[$i][3], $COLOR_DEBUG2)


### PR DESCRIPTION
# Rationale for this change

The Builder Base suggested-upgrades routine loops through buildings marked as `New`.

Previously, if placing one of those buildings failed, the entire loop stopped. That meant one problematic building could prevent every `New` building after it from ever being attempted.

I ran into this with `B.O.T.O's Shack`. It was sorted ahead of `Double Cannon`, but the Shack currently has no shop mapping or Gem-cost handling. The bot treated it like a normal purchase, failed, exited the loop, and never reached Double Cannon. Gold and Elixir just sat there even though other new buildings could have been placed.

## Changes

- If placing a `New` building fails, continue to the next candidate instead of aborting the loop.
- Detect `B.O.T.O's Shack` by name and skip it when `ChkBBIgnoreBOTOShack` is enabled.
- Add `ChkBBIgnoreBOTOShack` to `[other]` in `config.ini` (enabled by default).

The current new-building purchase code only supports Gold and Elixir. Since the Shack costs Gems, it was reading the Gem icon as Gold and trying to buy it anyway. Skipping it avoids wasting time and avoids unintended Gem purchases.

## Are these changes tested?

Yes. Tested on multiple live Builder Base accounts.

The logs show the Shack being skipped and the bot immediately moving on to the next building:

```text
18:17:37.330  B O T O s Shack ignored (BOTO's Shack, Gem cost)
18:17:38.428  PlaceNewBuildingFromShopBB : Double Cannon
18:18:05.376  Placed Double Cannon on Main Village! [353,197] 
```

## Are there any user-facing changes?

A new option has been added to `config.ini`:

```ini
ChkBBIgnoreBOTOShack=1
```

It is enabled by default. There isn't a GUI option yet, so it can only be changed manually in `config.ini`.

**Note:** Disabling this option is experimental. The new-building purchase code still does not support Gem-cost buildings, so the bot may try to treat the Gem purchase as Gold. Until Gem support is implemented, leaving this enabled is recommended.