### PR TITLE
fix: BB placement success log says Builder Base, not Main Village

### DIFF
--- a/COCBot/functions/Village/BuilderBase/SuggestedUpgrades.au3
+++ b/COCBot/functions/Village/BuilderBase/SuggestedUpgrades.au3
@@ -456,7 +456,7 @@ Func PlaceNewBuildingFromShopBB($sUpgrade = "", $bZoomedIn = False, $iCost = 0)
 			Return False
 		EndIf
 
-		SetLog("Placed " & $sUpgrade & " on Main Village! [" & $iClickX & "," & $iClickY & "]", $COLOR_SUCCESS)
+		SetLog("Placed " & $sUpgrade & " on Builder Base! [" & $iClickX & "," & $iClickY & "]", $COLOR_SUCCESS)
 		AutoUpgradeLog(True, "BB " & $sUpgrade, 1, $iCost, "New")
 		Return True
 	ElseIf QuickMIS("BFI", $g_sImgGreenCheckBB & "GreyCheck*") Then
@@ -485,7 +485,7 @@ Func PlaceNewBuildingFromShopBB($sUpgrade = "", $bZoomedIn = False, $iCost = 0)
 			EndIf
 		Next
 		If $bAnchorVerified Then
-			SetLog("Placed " & $sUpgrade & " on Main Village via RedX anchor! [" & $iRxClickX & "," & $iRxClickY & "]", $COLOR_SUCCESS)
+			SetLog("Placed " & $sUpgrade & " on Builder Base via RedX anchor! [" & $iRxClickX & "," & $iRxClickY & "]", $COLOR_SUCCESS)
 			AutoUpgradeLog(True, "BB " & $sUpgrade, 1, $iCost, "New")
 			Return True
 		EndIf


### PR DESCRIPTION
# Rationale for this change

Builder Base placement success messages were still logging:

```
Placed <building> on Main Village!
```

This was copied from `Auto Upgrade.au3` (Home Village) and never updated when the Builder Base code was added.

The incorrect message appeared on every successful Builder Base placement I tested. It was only a logging issue and did not affect placement behavior.

## Changes

- Update the success log to report `Builder Base` instead of `Main Village`.

## Are these changes tested?

Yes. Verified on multiple live Builder Base placements. Successful placements now log:

```text
Placed Double Cannon on Builder Base!
```

instead of:

```text
Placed Double Cannon on Main Village!
```

## Are there any user-facing changes?

Only the log message has changed. There is no behavior change.