### PR TITLE
feat: support Clash of Cards event (August)

### DIFF
--- a/COCBot/MBR Functions.au3
+++ b/COCBot/MBR Functions.au3
@@ -242,6 +242,7 @@
 #include "functions\Village\ReplayShare.au3"
 #include "functions\Village\BoostHeroes.au3"
 #include "functions\Village\UpgradeHeroes.au3"
+#include "functions\Village\ClashOfCards.au3"
 #include "functions\Village\AddIdleTime.au3"
 #include "functions\Village\GetVillageSize.au3"
 #include "functions\Village\GainCost.au3"

--- a/COCBot/functions/Attack/ReturnHome.au3
+++ b/COCBot/functions/Attack/ReturnHome.au3
@@ -75,10 +75,16 @@ Func ReturnHome($bTakeSS = True, $GoldChangeCheck = True) ;Return main screen
 		
 		If IsReturnHomeChestPage(False) Then
 			$BattleEnded = True
-			SetLog("Found ReturnHome ChestPage", $COLOR_DEBUG1) 
+			SetLog("Found ReturnHome ChestPage", $COLOR_DEBUG1)
 			ExitLoop ;exit Battle already ended
 		EndIf
-		
+
+		If IsClashOfCardsEventActive() And QuickMIS("BC1", $g_sImgCardTapIcon) Then
+			$BattleEnded = True
+			SetLog("Found ReturnHome Clash of Cards pack", $COLOR_DEBUG1)
+			ExitLoop ;exit Battle already ended
+		EndIf
+
 		If IsAttackPage() Then
 			Click(65, 540, 1, 0, "#0099")
 			If _Sleep(500) Then Return
@@ -141,6 +147,10 @@ Func ReturnHome($bTakeSS = True, $GoldChangeCheck = True) ;Return main screen
 				ContinueLoop
 			Case IsReturnHomeChestPage()
 				SetLog("Chest Bonus gained!", $COLOR_SUCCESS)
+				If _Sleep(2000) Then Return
+				ContinueLoop
+			Case CheckClashOfCards()
+				SetLog("Clash of Cards pack claimed!", $COLOR_SUCCESS)
 				If _Sleep(2000) Then Return
 				ContinueLoop
 			Case StarBonus()

--- a/COCBot/functions/Config/ImageDirectories.au3
+++ b/COCBot/functions/Config/ImageDirectories.au3
@@ -196,6 +196,9 @@ Global $g_sImgBuilderMenu = @ScriptDir & "\imgxml\Resources\AutoUpgrade\BuilderM
 Global $g_sImgHeroHall = @ScriptDir & "\imgxml\Resources\AutoUpgrade\HeroHall\"
 Global $g_sImgBuilderPotion = @ScriptDir & "\imgxml\Resources\AutoUpgrade\Potion\"
 Global $g_sImgHeroBooks = @ScriptDir & "\imgxml\Resources\AutoUpgrade\HeroBooks\"
+Global $g_sImgCardTapIcon = @ScriptDir & "\imgxml\Village\ClashOfCards\CardTapIcon\" ; Clash of Cards event (August) - "Tap!" card pack shown after battle ends
+Global $g_sImgContinueButton = @ScriptDir & "\imgxml\Village\ClashOfCards\ContinueButton\"
+Global $g_sImgClaimRewardButton = @ScriptDir & "\imgxml\Village\ClashOfCards\ClaimRewardButton\"
 #EndRegion
 
 #Region Auto Upgrade Builder Base

--- a/COCBot/functions/Main Screen/checkObstacles.au3
+++ b/COCBot/functions/Main Screen/checkObstacles.au3
@@ -358,7 +358,12 @@ Func PlacedOnLeague()
 		SetLog("You have Chest to open", $COLOR_DEBUG2)
 		Return RewardChest()
 	EndIf
-	
+
+	If IsClashOfCardsEventActive() Then
+		Local $bClashOfCardsHandled = CheckClashOfCards()
+		If $bClashOfCardsHandled Then Return True
+	EndIf
+
 	If QuickMIS("BC1", $g_sImgSurvey, 430, 80, 475, 110) Then
 		Click(275, 585, 1, 0, "No Thanks")
 		If _Sleep(2000) Then Return

--- a/COCBot/functions/Village/ClashOfCards.au3
+++ b/COCBot/functions/Village/ClashOfCards.au3
@@ -1,0 +1,100 @@
+; #FUNCTION# ====================================================================================================================
+; Name ..........: Clash of Cards
+; Description ...: Seasonal event (August only). Card packs are earned during attacks and, like the existing Chest
+;                   Event (IsReturnHomeChestPage() in Other/IsPage.au3), the reward is forced open right on the
+;                   end-battle screen before the bot can return to the main village: a "Tap!" card banner that
+;                   needs several taps to break open, followed by a Continue or Claim Reward button.
+; Remarks .......: Gated entirely behind IsClashOfCardsEventActive() (calendar month check) so this is a safe
+;                   no-op outside August, per the event being time-limited.
+; ===============================================================================================================================
+
+Func IsClashOfCardsEventActive()
+	Return @MON = 8
+EndFunc   ;==>IsClashOfCardsEventActive
+
+; Bounding regions confirmed live at 860x676 (Tap icon matched at [441,321], Continue at [448,517]), with margin.
+; An unbounded QuickMIS scans the whole screen at every scale and took 20-90s per call in testing - since this
+; now runs on every checkObstacles() call during waitMainScreen()'s retry loop, bounding it matters for speed,
+; not just correctness.
+Global Const $aClashOfCardsTapRegion[4] = [280, 170, 600, 470]
+Global Const $aClashOfCardsButtonRegion[4] = [370, 480, 550, 555]
+
+; Detects and opens a pending Clash of Cards pack, if any. Safe no-op if the event isn't active this month or no
+; pack is currently shown. Mirrors IsReturnHomeChestPage()'s tap-then-continue pattern (Other/IsPage.au3:236).
+; Also handles being caught mid-flow (e.g. CoC was force-restarted while the pack was already tapped open, so
+; only Continue/Claim Reward is visible, never the Tap icon) - important since checkObstacles() calls this on
+; every waitMainScreen() retry, and a restart mid-pack is exactly the state that used to loop forever.
+Func CheckClashOfCards($bSetLog = True)
+	If Not IsClashOfCardsEventActive() Then Return False
+	If Not $g_bRunState Then Return False
+
+	Local $bTapIconFound = QuickMIS("BC1", $g_sImgCardTapIcon, $aClashOfCardsTapRegion[0], $aClashOfCardsTapRegion[1], $aClashOfCardsTapRegion[2], $aClashOfCardsTapRegion[3])
+	If Not $bTapIconFound And Not QuickMIS("BC1", $g_sImgContinueButton, $aClashOfCardsButtonRegion[0], $aClashOfCardsButtonRegion[1], $aClashOfCardsButtonRegion[2], $aClashOfCardsButtonRegion[3]) And Not QuickMIS("BC1", $g_sImgClaimRewardButton, $aClashOfCardsButtonRegion[0], $aClashOfCardsButtonRegion[1], $aClashOfCardsButtonRegion[2], $aClashOfCardsButtonRegion[3]) Then
+		Return False ; nothing pending, cheap no-op
+	EndIf
+
+	If $bTapIconFound Then
+		If $bSetLog Then SetLog("Clash of Cards: pack found, tapping to open", $COLOR_ACTION)
+		For $i = 1 To 10 ; the pack needs a handful of taps to break open (observed: 3), pad out to be safe
+			Click($g_iQuickMISX, $g_iQuickMISY, 1, 0, "Tap Card Pack")
+			If _Sleep(700) Then Return
+		Next
+	Else
+		If $bSetLog Then SetLog("Clash of Cards: caught already open (Continue/Claim Reward visible), skipping tap", $COLOR_ACTION)
+	EndIf
+
+	Local $bClosed = False
+	For $i = 1 To 10
+		If QuickMIS("BC1", $g_sImgContinueButton, $aClashOfCardsButtonRegion[0], $aClashOfCardsButtonRegion[1], $aClashOfCardsButtonRegion[2], $aClashOfCardsButtonRegion[3]) Then
+			Click($g_iQuickMISX, $g_iQuickMISY, 1, 0, "Click Continue")
+			$bClosed = True
+			ExitLoop
+		EndIf
+		If QuickMIS("BC1", $g_sImgClaimRewardButton, $aClashOfCardsButtonRegion[0], $aClashOfCardsButtonRegion[1], $aClashOfCardsButtonRegion[2], $aClashOfCardsButtonRegion[3]) Then
+			Click($g_iQuickMISX, $g_iQuickMISY, 1, 0, "Click Claim Reward")
+			$bClosed = True
+			ExitLoop
+		EndIf
+		If _Sleep(1000) Then Return
+	Next
+
+	If $bSetLog Then
+		If $bClosed Then
+			SetLog("Clash of Cards: pack opened and claimed", $COLOR_SUCCESS)
+		Else
+			SetLog("Clash of Cards: opened pack but Continue/Claim Reward button not found", $COLOR_ERROR)
+		EndIf
+	EndIf
+	Return $bClosed
+EndFunc   ;==>CheckClashOfCards
+
+; Detect-only smoke test - call via Test420 to confirm the template actually matches live before relying on
+; CheckClashOfCards() for real. Does not tap/claim anything.
+Func ClashOfCards_Test()
+	If Not IsClashOfCardsEventActive() Then
+		SetLog("ClashOfCards_Test: event not active this month (August only)", $COLOR_INFO)
+		Return False
+	EndIf
+
+	; checks all three templates independently - whichever screen you're actually on (tap card, or the
+	; reward/Continue screen after it's already opened) will report a match, the others just won't
+	If QuickMIS("BC1", $g_sImgCardTapIcon, $aClashOfCardsTapRegion[0], $aClashOfCardsTapRegion[1], $aClashOfCardsTapRegion[2], $aClashOfCardsTapRegion[3]) Then
+		SetLog("ClashOfCards_Test: Tap card icon FOUND at [" & $g_iQuickMISX & "," & $g_iQuickMISY & "]", $COLOR_SUCCESS)
+	Else
+		SetLog("ClashOfCards_Test: Tap card icon NOT found (not on that screen, or template needs tuning)", $COLOR_INFO)
+	EndIf
+
+	If QuickMIS("BC1", $g_sImgContinueButton, $aClashOfCardsButtonRegion[0], $aClashOfCardsButtonRegion[1], $aClashOfCardsButtonRegion[2], $aClashOfCardsButtonRegion[3]) Then
+		SetLog("ClashOfCards_Test: Continue button FOUND at [" & $g_iQuickMISX & "," & $g_iQuickMISY & "]", $COLOR_SUCCESS)
+	Else
+		SetLog("ClashOfCards_Test: Continue button NOT found (not on that screen, or template needs tuning)", $COLOR_INFO)
+	EndIf
+
+	If QuickMIS("BC1", $g_sImgClaimRewardButton, $aClashOfCardsButtonRegion[0], $aClashOfCardsButtonRegion[1], $aClashOfCardsButtonRegion[2], $aClashOfCardsButtonRegion[3]) Then
+		SetLog("ClashOfCards_Test: Claim Reward button FOUND at [" & $g_iQuickMISX & "," & $g_iQuickMISY & "]", $COLOR_SUCCESS)
+	Else
+		SetLog("ClashOfCards_Test: Claim Reward button NOT found (not on that screen, or template needs tuning)", $COLOR_INFO)
+	EndIf
+
+	Return True
+EndFunc   ;==>ClashOfCards_Test


### PR DESCRIPTION
# Rationale for this change

The new Clash of Cards event gives players card packs during attacks. These packs are forced open on the end-of-battle screen before the bot can return to the Home Village. We are also given a pack on first login during the event.

The interaction is similar to the existing Chest Event:

1. Tap the card pack several times to open it.
2. Click `Continue` 
3. Return to normal bot operation.

Without handling this screen, the pack will block the bot from returning after an attack. This is problematic as it will force an emulator game restart and get stuff in a loop, repeatedly restart the game while the same pack remains open and continues blocking the main screen.

## Changes

* Add `ClashOfCards.au3` with:

  * `IsClashOfCardsEventActive()`
  * `CheckClashOfCards()`
  * `ClashOfCards_Test()`
* Limit event checks to August so the feature is a safe no-op outside the event period.
* Detect and open the initial card pack screen.
* Handle cases where the bot is already partway through the opening flow and only `Continue` or `Claim Reward` is visible.
* Add bounded image-search regions to avoid expensive full-screen template searches.
* Add the required image directory paths for the card icon, Continue button, and Claim Reward button.
* Hook the handler into `ReturnHome.au3` at the same two stages used by the existing Chest Event logic.
* Hook the handler into `PlacedOnLeague()` so pending packs can also be cleared during `waitMainScreen()` retries.

## Are these changes tested?

Yes.

Tested on several accounts

Verified that the bot can:

* Detect a newly earned card pack after an attack.
* Tap the pack open.
* Click `Continue` or `Claim Reward`.
* Recover when Clash of Clans restarts while the pack is already partially opened.
* Return to the Home Village without entering a repeated restart loop.

A debug smoke test is also included to verify each image template independently without tapping or claiming the reward.

## Are there any user-facing changes?

Yes.

During the Clash of Cards event, the bot will automatically open and claim card packs earned from attacks.

Outside August, the new logic does nothing.
